### PR TITLE
Fix <head> being stripped from emails

### DIFF
--- a/src/EmogrifierPlugin.php
+++ b/src/EmogrifierPlugin.php
@@ -38,7 +38,7 @@ class EmogrifierPlugin implements Swift_Events_SendListener
 
         $body = $message->getBody();
         if (!empty($body) && $message->getContentType() !== 'text/plain') {
-            $html = CssInliner::fromHtml($body)->inlineCss($this->css ?? '')->renderBodyContent();
+            $html = CssInliner::fromHtml($body)->inlineCss($this->css ?? '')->render();
             $message->setBody($html);
         }
 
@@ -50,7 +50,7 @@ class EmogrifierPlugin implements Swift_Events_SendListener
                     continue;
                 }
 
-                $html = CssInliner::fromHtml($body)->inlineCss($this->css ?? '')->renderBodyContent();
+                $html = CssInliner::fromHtml($body)->inlineCss($this->css ?? '')->render();
                 $messagePart->setBody($html);
             }
         }


### PR DESCRIPTION
`renderBodyContent()` will return just the contents of the `<body>` tag, meaning that media queries (which can’t be inlined, and have to live in the `<head>`) are lost.

`$message->setBody()` refers to the “email body”, rather than the `<body>` element of the email’s HTML content